### PR TITLE
[FEATURE]: adding node discovery task, for finding another peers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ log = "0.4.25"
 ordered-float = "4.6.0"
 actix-web = "4.9.0"
 thiserror = "2.0.11"
+uuid = { version = "1.13.1", features = ["v4"] }
 
 [features]
 dev = []

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -13,7 +13,7 @@ impl Blockchain {
         let genesis_block = Block::new(0, 0, vec![], "0".to_string());
         Blockchain {
             chain: vec![genesis_block],
-            difficulty: 4, // Set the PoW difficulty (e.g., 4 leading zeros)
+            difficulty: 5, // Set the PoW difficulty (e.g., 4 leading zeros)
         }
     }
 

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -1,0 +1,81 @@
+use crate::discover_info;
+use crate::server::Request;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::sync::Mutex;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct Peer {
+    pub(crate) id: String,
+    pub(crate) address: String,
+}
+
+pub struct Discover {
+    peers: Arc<Mutex<HashSet<String>>>,
+}
+
+impl Discover {
+    pub fn new(peers: Arc<Mutex<HashSet<String>>>) -> Self {
+        Self { peers }
+    }
+
+    pub async fn find_peers(
+        &mut self,
+        node_id: String,
+        tcp_address: String,
+        boostrap_address: String,
+    ) {
+        loop {
+            discover_info!("Looking for peers on bootstrap node");
+            if let Ok(mut stream) = TcpStream::connect(&boostrap_address).await {
+                let this_peer = Peer {
+                    id: node_id.clone(),
+                    address: tcp_address.clone(),
+                };
+
+                // Send request to register itself in the bootstrap node
+                let request = Request {
+                    command: "register".to_string(),
+                    data: serde_json::to_string(&this_peer).unwrap(),
+                };
+
+                let marshalled_request = serde_json::to_string(&request).unwrap();
+
+                // TODO - Add fatal error for connecting to invalid bootstrap node
+                if stream
+                    .write_all(marshalled_request.as_bytes())
+                    .await
+                    .is_err()
+                {
+                    continue;
+                }
+
+                let mut buffer = [0; 1024];
+                if let Ok(n) = stream.read(&mut buffer).await {
+                    let data = String::from_utf8_lossy(&buffer[..n]);
+                    if let Ok(remote_peers) = serde_json::from_str::<HashSet<String>>(&data) {
+                        for address in remote_peers {
+                            if address != tcp_address {
+                                {
+                                    let mut peers = self.peers.lock().await;
+                                    if !peers.contains(&address.clone()) {
+                                        discover_info!(
+                                            "New peer discovered on address: {}",
+                                            address
+                                        );
+                                        peers.insert(address);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            tokio::time::sleep(tokio::time::Duration::from_secs(120)).await;
+        }
+    }
+}

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -93,6 +93,27 @@ macro_rules! sync_warn {
     };
 }
 
+#[macro_export]
+macro_rules! discover_info {
+    ($($arg:tt)*) => {
+        info!(target: "discover", "{}", format_args!($($arg)*))
+    };
+}
+
+#[macro_export]
+macro_rules! discover_error {
+    ($($arg:tt)*) => {
+        error!(target: "discover", "{}", format_args!($($arg)*))
+    };
+}
+
+#[macro_export]
+macro_rules! discover_warn {
+    ($($arg:tt)*) => {
+        warn!(target: "discover", "{}", format_args!($($arg)*))
+    };
+}
+
 pub fn init_logger() {
     Builder::new()
         .filter(None, LevelFilter::Debug) // Keep all debug logs
@@ -106,6 +127,7 @@ pub fn init_logger() {
                 "miner" => "[MINER]",
                 "broadcaster" => "[BROADCASTER]",
                 "sync" => "[SYNC]",
+                "discover" => "[DISCOVER]",
                 _ => "[GENERAL]", // Default prefix
             };
             writeln!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ extern crate log;
 mod block;
 mod blockchain;
 mod broadcaster;
+mod discover;
 mod error;
 mod handler;
 mod logger;
@@ -32,9 +33,9 @@ struct Args {
     #[arg(short, long)]
     rpc_bind: String,
 
-    /// List of peer nodes (comma-separated, e.g., 127.0.0.1:8333,192.168.1.1:8333)
+    /// Address of the bootstrap node for registering as a new peer (full-nodes will leave this empty)
     #[arg(short, long, default_value = "")]
-    peers: String,
+    bootstrap_address: String,
 }
 
 #[tokio::main]
@@ -51,13 +52,9 @@ async fn main() {
     let http_bind_addr = args.rpc_bind;
 
     // Extract peers
-    let peers: Vec<String> = args
-        .peers
-        .split(',')
-        .filter(|peer| !peer.is_empty()) // Remove empty strings from split
-        .map(|peer| peer.to_string())
-        .collect();
+    let bootstrap_address = args.bootstrap_address;
 
-    let node = Node::new(peers);
-    node.start(tcp_bind_addr, http_bind_addr).await;
+    let node = Node::new();
+    node.start(tcp_bind_addr, http_bind_addr, bootstrap_address)
+        .await;
 }

--- a/src/miner.rs
+++ b/src/miner.rs
@@ -38,6 +38,8 @@ impl Miner {
     }
 
     pub async fn mine(&mut self) {
+        // First 15-seconds sleep, for giving time for collecting first peers and new chain
+        tokio::time::sleep(Duration::from_secs(15)).await;
         loop {
             let data = {
                 self.transaction_pool
@@ -122,6 +124,11 @@ impl Miner {
                             .broadcast_new_block(&new_block)
                             .await;
                     }
+                    // Adding a 2-second delay on the miner that wins to make the process fair
+                    // In production blockchains,
+                    // like bitcoin's, there are a lot of built-in redundancy
+                    // and mechanisms to handle edge cases.
+                    tokio::time::sleep(Duration::from_secs(2)).await;
                 } else {
                     miner_info!("Mining became invalid due to a chain update.");
                     continue; // Restart the mining loop
@@ -129,7 +136,7 @@ impl Miner {
             }
 
             // Reset and restart on interruption or completion
-            tokio::time::sleep(Duration::from_secs(1)).await;
+            // tokio::time::sleep(Duration::from_secs(1)).await;
             miner_info!("Restarting mining...");
         }
     }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -55,7 +55,7 @@ impl Sync {
                         continue;
                     }
 
-                    let mut buffer = [0; 100000];
+                    let mut buffer = [0; 8184];
                     if let Ok(n) = stream.read(&mut buffer).await {
                         let data = String::from_utf8_lossy(&buffer[..n]);
                         if let Ok(peer_chain) = serde_json::from_str::<Vec<Block>>(&data) {


### PR DESCRIPTION
## Adding node discovery task, for finding another peers

### Description

Before this feature, nodes were communicating with each other through cli commands, providing a list of address of existing nodes, when starting a new node.

This feature separate nodes into two types: `bootstrap` and `normal`, the bootstrap one will be responsible for receiving requests of new peers, and broadcasting to the new ones a list of peers.

The normal node, will be started with a command line argument(`bootstrap-address`), detailing the address of an existing bootstrap node, and will periodically register itself in the bootstrap node, receiving back the list of peers.

